### PR TITLE
Fix the crash when build & run the binary (Fixed #8)

### DIFF
--- a/ColorArt/PCFadedImageView.m
+++ b/ColorArt/PCFadedImageView.m
@@ -31,7 +31,7 @@
 	[self.image drawInRect:imageRect fromRect:NSZeroRect operation:NSCompositeSourceOver fraction:1.0];
 
 	// lazy way to get fade color
-	NSColor *backgroundColor = [[self window] backgroundColor];
+	NSColor *backgroundColor = [NSColor colorWithCGColor:[[self window] backgroundColor].CGColor];
 		
 	NSGradient *gradient = [[NSGradient alloc] initWithColorsAndLocations:backgroundColor, 0.0, backgroundColor, .01, [backgroundColor colorWithAlphaComponent:0.05], 1.0, nil];
 


### PR DESCRIPTION
  Error:
    *** Terminating app due to uncaught exception
  'NSInvalidArgumentException', reason: '*** -[NSGradient
  initWithColors:atLocations:colorSpace:]: the color NSNamedColorSpace
  System windowBackgroundColor cannot be converted into color space
  Generic RGB colorspace'

  Issue link: https://github.com/panicinc/ColorArt/issues/8